### PR TITLE
implement upload asset method for stitch client

### DIFF
--- a/api/stitch.go
+++ b/api/stitch.go
@@ -366,13 +366,10 @@ func (sc *basicStitchClient) UploadAsset(groupID, appID, path, hash string, size
 	bodyWriter := multipart.NewWriter(pipeWriter)
 	go func() (err error) {
 		defer func() {
-			if err != nil {
-				// If building the request failed, force the reader side to fail
-				// so that ExecuteRequest returns the error.
-				pipeWriter.CloseWithError(err)
-			} else {
-				pipeWriter.Close()
-			}
+			// If building the request failed, force the reader side to fail
+			// so that ExecuteRequest returns the error. This behaves equivalent to
+			// .Close() if err is nil.
+			pipeWriter.CloseWithError(err)
 			bodyWriter.Close()
 		}()
 		// Create the first part and write the metadata into it

--- a/api/stitch.go
+++ b/api/stitch.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"mime/multipart"
 	"net/http"
 	"strings"
 
@@ -20,6 +21,7 @@ const (
 	appImportRoute         = adminBaseURL + "/groups/%s/apps/%s/import"
 	appsByGroupIDRoute     = adminBaseURL + "/groups/%s/apps"
 	userProfileRoute       = adminBaseURL + "/auth/profile"
+	hostingAssetRoute      = adminBaseURL + "/groups/%s/apps/%s/hosting/assets/asset"
 )
 
 var (
@@ -123,7 +125,13 @@ type StitchClient interface {
 	FetchAppByClientAppID(clientAppID string) (*models.App, error)
 	FetchAppsByGroupID(groupID string) ([]*models.App, error)
 	CreateEmptyApp(groupID, appName string) (*models.App, error)
+	UploadAsset(groupID, appID, path, hash string, size int64, body io.Reader, attributes ...AssetAttribute) error
 }
+
+const (
+	metadataParam = "meta"
+	fileParam     = "file"
+)
 
 // NewStitchClient returns a new StitchClient to be used for making calls to the Stitch Admin API
 func NewStitchClient(client Client) StitchClient {
@@ -332,6 +340,79 @@ func (sc *basicStitchClient) CreateEmptyApp(groupID, appName string) (*models.Ap
 	}
 
 	return &app, nil
+}
+
+func (sc *basicStitchClient) UploadAsset(groupID, appID, path, hash string, size int64, body io.Reader, attributes ...AssetAttribute) error {
+	// The upload request consists of a multipart body with two parts:
+	// 1) the metadata, as json, and 2) the file data itself.
+
+	// First build the metadata part
+	metaPart, err := json.Marshal(AssetMetadata{
+		AppID:    appID,
+		FilePath: path,
+		FileHash: hash,
+		FileSize: size,
+		Attrs:    attributes,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Construct a pipe stream: the reader side will be consumed and sent as the
+	// body of the outgoing request, and the writer side we can use to
+	// asynchronously populate it.
+	pipeReader, pipeWriter := io.Pipe()
+
+	bodyWriter := multipart.NewWriter(pipeWriter)
+	go func() (err error) {
+		defer func() {
+			if err != nil {
+				// If building the request failed, force the reader side to fail
+				// so that ExecuteRequest returns the error.
+				pipeWriter.CloseWithError(err)
+			} else {
+				pipeWriter.Close()
+			}
+			bodyWriter.Close()
+		}()
+		// Create the first part and write the metadata into it
+		metaWriter, formErr := bodyWriter.CreateFormField(metadataParam)
+		if err != nil {
+			return fmt.Errorf("failed to create metadata multipart field: %s", formErr)
+		}
+
+		if _, metaErr := metaWriter.Write(metaPart); metaErr != nil {
+			return fmt.Errorf("failed to write metadata to body: %s", metaErr)
+		}
+
+		// Create the second part, stream the file body into it, then close it.
+		fileWriter, fileErr := bodyWriter.CreateFormField(fileParam)
+		if fileErr != nil {
+			return fmt.Errorf("failed to create metadata multipart field: %s", fileErr)
+		}
+
+		if _, copyErr := io.Copy(fileWriter, body); copyErr != nil {
+			return fmt.Errorf("failed to write file to body: %s", copyErr)
+		}
+		return nil
+	}()
+
+	res, err := sc.ExecuteRequest(
+		http.MethodPut,
+		fmt.Sprintf(hostingAssetRoute, groupID, appID),
+		RequestOptions{
+			Body:   pipeReader,
+			Header: http.Header{"Content-Type": {"multipart/mixed; boundary=" + bodyWriter.Boundary()}},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("%s: failed to upload asset: %s", res.Status, UnmarshalStitchError(res))
+	}
+	return nil
 }
 
 func findAppByClientAppID(apps []*models.App, clientAppID string) *models.App {

--- a/api/stitch_test.go
+++ b/api/stitch_test.go
@@ -1,7 +1,15 @@
 package api_test
 
 import (
+	"bytes"
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -32,5 +40,97 @@ func TestErrStitchResponse(t *testing.T) {
 			Body: u.NewResponseBody(strings.NewReader(`{ "error": "something went horribly, horribly wrong" }`)),
 		})
 		u.So(t, err, gc.ShouldBeError, "error: something went horribly, horribly wrong")
+	})
+}
+
+// md5Sum returns the md5 hash sum of the input string
+func md5Sum(in string) string {
+	h := md5.New()
+	io.WriteString(h, in)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func TestUploadAsset(t *testing.T) {
+
+	var testHandler http.HandlerFunc
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testHandler(w, r)
+	}))
+
+	testContents := "hello world"
+	t.Run("uploading an asset should work", func(t *testing.T) {
+
+		var uploadedAssetMetadata api.AssetMetadata
+		uploadedFileData := &bytes.Buffer{}
+
+		testHandler = func(w http.ResponseWriter, r *http.Request) {
+			mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if !strings.HasPrefix(mediaType, "multipart/") {
+				http.Error(w, "invalid multipart header", http.StatusBadRequest)
+				return
+			}
+			mpr := multipart.NewReader(r.Body, params["boundary"])
+
+			// Read the first section from the body which contains metadata about the asset
+			metaReader, err := mpr.NextPart()
+			if err != nil || metaReader.FormName() != "meta" {
+				http.Error(w, "invalid multipart form name", http.StatusBadRequest)
+				return
+			}
+
+			metaDecoder := json.NewDecoder(metaReader)
+			metaDecoderErr := metaDecoder.Decode(&uploadedAssetMetadata)
+			if metaDecoderErr != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			// Read the file data
+			dataReader, err := mpr.NextPart()
+			if err != nil || dataReader.FormName() != "file" {
+				http.Error(w, "invalid multipart form name", http.StatusBadRequest)
+				return
+			}
+
+			if _, err = io.Copy(uploadedFileData, dataReader); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}
+
+		path, hash, size := "/test", md5Sum(testContents), int64(len(testContents))
+
+		testClient := api.NewStitchClient(api.NewClient(testServer.URL))
+		testClient.UploadAsset(
+			"groupid",
+			"appid",
+			path,
+			hash,
+			size,
+			strings.NewReader(testContents),
+			api.AssetAttribute{
+				Name:  "Content-Type",
+				Value: "application/json",
+			},
+		)
+
+		u.So(t, uploadedAssetMetadata, gc.ShouldResemble, api.AssetMetadata{
+			AppID:    "appid",
+			FilePath: path,
+			FileHash: hash,
+			FileSize: size,
+			Attrs: []api.AssetAttribute{
+				{
+					Name:  "Content-Type",
+					Value: "application/json",
+				},
+			},
+		})
 	})
 }

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -191,6 +191,7 @@ type MockStitchClient struct {
 	FetchAppByGroupIDAndClientAppIDFn func(groupID, clientAppID string) (*models.App, error)
 	FetchAppByClientAppIDFn           func(clientAppID string) (*models.App, error)
 	FetchAppsByGroupIDFn              func(groupID string) ([]*models.App, error)
+	UploadAssetFn                     func(groupID, appID, path, hash string, size int64, body io.Reader, attributes ...api.AssetAttribute) error
 
 	ExportFn      func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error)
 	ExportFnCalls [][]string
@@ -268,6 +269,15 @@ func (msc *MockStitchClient) FetchAppByClientAppID(clientAppID string) (*models.
 	}
 
 	return nil, api.ErrAppNotFound{clientAppID}
+}
+
+// UploadAsset uploads an asset
+func (msc *MockStitchClient) UploadAsset(groupID, appID, path, hash string, size int64, body io.Reader, attributes ...api.AssetAttribute) error {
+	if msc.UploadAssetFn != nil {
+		return msc.UploadAssetFn(groupID, appID, path, hash, size, body, attributes...)
+	}
+
+	return nil
 }
 
 // MockMDBClient satisfies a mdbcloud.Client


### PR DESCRIPTION
This is a precursor to STITCH-2124 and also should provide a base for how to do testing for the rest of the hosting-related CLI tickets on deck.