### PR TITLE
STITCH-2194 assign content type based on file extension when no asset description for path exists

### DIFF
--- a/commands/cloud_test.go
+++ b/commands/cloud_test.go
@@ -52,6 +52,7 @@ func TestCloudCommands(t *testing.T) {
 		"--yes",
 	}
 	out, err := exec.Command("go", importArgs...).Output()
+	t.Logf("Output from import command: '%s'", string(out))
 	u.So(t, err, gc.ShouldBeNil)
 
 	importOut := string(out)

--- a/commands/cloud_test.go
+++ b/commands/cloud_test.go
@@ -31,9 +31,12 @@ func TestCloudCommands(t *testing.T) {
 		cloudEnv.APIKey,
 	}
 
-	err := exec.Command("go", loginArgs...).Run()
+	out, err := exec.Command("go", loginArgs...).Output()
+	t.Logf("output from login command: %s", string(out))
 	u.So(t, err, gc.ShouldBeNil)
-	err = exec.Command("ls", "../cli_conf").Run()
+
+	out, err = exec.Command("ls", "../cli_conf").Output()
+	t.Logf("output from ls command: %s", string(out))
 	u.So(t, err, gc.ShouldBeNil)
 
 	// test import
@@ -51,7 +54,7 @@ func TestCloudCommands(t *testing.T) {
 		cloudEnv.GroupID,
 		"--yes",
 	}
-	out, err := exec.Command("go", importArgs...).Output()
+	out, err = exec.Command("go", importArgs...).Output()
 	t.Logf("Output from import command: '%s'", string(out))
 	u.So(t, err, gc.ShouldBeNil)
 

--- a/commands/import.go
+++ b/commands/import.go
@@ -228,7 +228,7 @@ func (ic *ImportCommand) importApp() error {
 	if ic.flagIncludeHosting {
 		assetDescs, fileErr := hosting.MetadataFileToAssetDescriptions(filepath.Join(appPath, utils.HostingAttributes))
 		if fileErr != nil {
-			return errIncludeHosting(fileErr)
+			return errIncludeHosting(fmt.Errorf("error loading metadata.json file: %v", fileErr))
 		}
 
 		cachePath, cPErr := getAssetCachePath(ic.flagConfigPath)

--- a/commands/import.go
+++ b/commands/import.go
@@ -259,7 +259,7 @@ func (ic *ImportCommand) importApp() error {
 
 		remoteAssetMetadata, rAMErr := stitchClient.ListAssetsForAppID(app.GroupID, app.ID)
 		if rAMErr != nil {
-			return errIncludeHosting(fmt.Errorf("error retrieving remote assets: %s", aMErr))
+			return errIncludeHosting(fmt.Errorf("error retrieving remote assets: %s", rAMErr))
 		}
 
 		assetMetadataDiffs = hosting.DiffAssetMetadata(localAssetMetadata, remoteAssetMetadata, ic.flagStrategy == importStrategyMerge)

--- a/hosting/hosting_test.go
+++ b/hosting/hosting_test.go
@@ -14,98 +14,134 @@ import (
 	gc "github.com/smartystreets/goconvey/convey"
 )
 
-func localFileToAssetMetadata(t *testing.T, localPath, rootDir string, assetDescriptions map[string]hosting.AssetDescription) *hosting.AssetMetadata {
-	file, err := os.Open(localPath)
-	u.So(t, err, gc.ShouldBeNil)
-	defer file.Close()
+func mustGenerateFileHash(path string) string {
+	fileHashStr, hashErr := utils.GenerateFileHashStr(path)
+	if hashErr != nil {
+		panic(hashErr)
+	}
+	return fileHashStr
+}
 
-	info, statErr := file.Stat()
-	u.So(t, statErr, gc.ShouldBeNil)
-
-	fileHashStr, hashErr := utils.GenerateFileHashStr(localPath)
-	u.So(t, hashErr, gc.ShouldBeNil)
-
-	appID := "3720"
-	relPath, pathErr := filepath.Rel(rootDir, localPath)
-	u.So(t, pathErr, gc.ShouldBeNil)
-	filePath := fmt.Sprintf("/%s", relPath)
-	assetCache := hosting.NewAssetCache()
-	assetMetadata, famErr := hosting.FileToAssetMetadata(appID, localPath, filePath, info, assetDescriptions, assetCache)
-	u.So(t, famErr, gc.ShouldBeNil)
-	u.So(t, assetCache.Dirty(), gc.ShouldBeTrue)
-
-	u.So(t, assetMetadata.AppID, gc.ShouldEqual, appID)
-	u.So(t, assetMetadata.FilePath, gc.ShouldEqual, filePath)
-	u.So(t, assetMetadata.FileHash, gc.ShouldEqual, fileHashStr)
-	u.So(t, assetMetadata.FileSize, gc.ShouldEqual, info.Size())
-
-	return assetMetadata
+func mustGetFileInfo(path string) os.FileInfo {
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		panic(statErr)
+	}
+	return info
 }
 
 func TestListLocalAssetMetadata(t *testing.T) {
-	var testData []hosting.AssetMetadata
-	path0 := "../testdata/full_app/hosting/files/asset_file0.json"
-	path1 := "../testdata/full_app/hosting/files/ships/nostromo.json"
-	path2 := "../testdata/full_app/hosting/files/asset_file1.html"
-	fp0, fErr := filepath.Abs(path0)
-	u.So(t, fErr, gc.ShouldBeNil)
-	fp1, fErr := filepath.Abs(path1)
-	u.So(t, fErr, gc.ShouldBeNil)
-	fp2, fErr := filepath.Abs(path2)
-	u.So(t, fErr, gc.ShouldBeNil)
+	const (
+		testAppID = "3720"
+		filesRoot = "../testdata/full_app/hosting/files/"
+		path0     = "/asset_file0.json"
+		path1     = "/ships/nostromo.json"
+		path2     = "/asset_file1.html"
+	)
 
 	rootDir, fErr := filepath.Abs("../testdata/full_app/hosting/files")
-
-	jsonAttr := hosting.AssetAttribute{
-		Name:  hosting.AttributeContentType,
-		Value: "json",
-	}
-	p0 := fmt.Sprintf("/%s", path0)
-	p1 := fmt.Sprintf("/%s", path1)
-	assetDescriptions := map[string]hosting.AssetDescription{
-		p0: {
-			FilePath: p0,
-			Attrs:    []hosting.AssetAttribute{jsonAttr},
-		},
-		p1: {
-			FilePath: p1,
-			Attrs:    []hosting.AssetAttribute{jsonAttr},
-		},
-	}
-
-	am0 := localFileToAssetMetadata(t, fp0, rootDir, assetDescriptions)
-	am1 := localFileToAssetMetadata(t, fp1, rootDir, assetDescriptions)
-	am2 := localFileToAssetMetadata(t, fp2, rootDir, assetDescriptions)
-	testData = append(testData, *am0, *am2, *am1)
-
 	u.So(t, fErr, gc.ShouldBeNil)
-	file, err := os.Open(rootDir)
-	u.So(t, err, gc.ShouldBeNil)
-	defer file.Close()
-
-	info, statErr := file.Stat()
-	u.So(t, statErr, gc.ShouldBeNil)
-	u.So(t, info.IsDir(), gc.ShouldBeTrue)
-
 	appID := "3720"
 	assetCache := hosting.NewAssetCache()
+	assetDescriptions := map[string]hosting.AssetDescription{
+		path0: {
+			FilePath: path0,
+			Attrs:    []hosting.AssetAttribute{jsonAttr},
+		},
+		path1: {
+			FilePath: path1,
+			Attrs: []hosting.AssetAttribute{
+				{Name: "Content-Type", Value: "application/octet-stream"},
+			},
+		},
+	}
 	assetMetadata, listErr := hosting.ListLocalAssetMetadata(appID, rootDir, assetDescriptions, assetCache)
 	u.So(t, listErr, gc.ShouldBeNil)
-	u.So(t, assetCache.Dirty(), gc.ShouldBeTrue)
+
+	localPath0, localPath1, localPath2 := filepath.Join(filesRoot, path0), filepath.Join(filesRoot, path1), filepath.Join(filesRoot, path2)
+	fileInfo0, fileInfo1, fileInfo2 := mustGetFileInfo(localPath0), mustGetFileInfo(localPath1), mustGetFileInfo(localPath2)
+
+	testData := []hosting.AssetMetadata{
+		{
+			AppID:        testAppID,
+			FilePath:     path0,
+			FileHash:     mustGenerateFileHash(localPath0),
+			FileSize:     fileInfo0.Size(),
+			LastModified: fileInfo0.ModTime().Unix(),
+			Attrs: []hosting.AssetAttribute{
+				// Derived from entry in asset descriptions
+				{Name: hosting.AttributeContentType, Value: "json"},
+			},
+		},
+		{
+			AppID:        testAppID,
+			FilePath:     path2,
+			FileHash:     mustGenerateFileHash(localPath2),
+			FileSize:     fileInfo2.Size(),
+			LastModified: fileInfo2.ModTime().Unix(),
+			Attrs: []hosting.AssetAttribute{
+				// Does not exist in assetDescriptions, so content type is populated from
+				// extension
+				{Name: hosting.AttributeContentType, Value: "text/html"},
+			},
+		},
+		{
+			AppID:        testAppID,
+			FilePath:     path1,
+			FileHash:     mustGenerateFileHash(localPath1),
+			FileSize:     fileInfo1.Size(),
+			LastModified: fileInfo1.ModTime().Unix(),
+			Attrs: []hosting.AssetAttribute{
+				// Derived from entry in asset descriptions, overrides extension default
+				{Name: hosting.AttributeContentType, Value: "application/octet-stream"},
+			},
+		},
+	}
+
 	u.So(t, assetMetadata, gc.ShouldResemble, testData)
 
-	ace0, ok := assetCache.Get(appID, am0.FilePath)
-	u.So(t, ok, gc.ShouldBeTrue)
+	t.Run("asset cache should be updated from local listing", func(t *testing.T) {
+		entry, ok := assetCache.Get(testAppID, path0)
+		u.So(t, ok, gc.ShouldBeTrue)
+		u.So(
+			t,
+			entry,
+			gc.ShouldResemble,
+			hosting.AssetCacheEntry{
+				FilePath:     path0,
+				LastModified: fileInfo0.ModTime().Unix(),
+				FileSize:     fileInfo0.Size(),
+				FileHash:     mustGenerateFileHash(localPath0),
+			},
+		)
+		entry, ok = assetCache.Get(testAppID, path1)
+		u.So(t, ok, gc.ShouldBeTrue)
+		u.So(
+			t,
+			entry,
+			gc.ShouldResemble,
+			hosting.AssetCacheEntry{
+				FilePath:     path1,
+				LastModified: fileInfo1.ModTime().Unix(),
+				FileSize:     fileInfo1.Size(),
+				FileHash:     mustGenerateFileHash(localPath1),
+			},
+		)
 
-	u.So(t, ace0.FileHash, gc.ShouldEqual, am0.FileHash)
-	u.So(t, ace0.FilePath, gc.ShouldEqual, am0.FilePath)
-	u.So(t, ace0.FileSize, gc.ShouldEqual, am0.FileSize)
-
-	ace1, ok := assetCache.Get(appID, am1.FilePath)
-	u.So(t, ok, gc.ShouldBeTrue)
-	u.So(t, ace1.FileHash, gc.ShouldEqual, am1.FileHash)
-	u.So(t, ace1.FilePath, gc.ShouldEqual, am1.FilePath)
-	u.So(t, ace1.FileSize, gc.ShouldEqual, am1.FileSize)
+		entry, ok = assetCache.Get(testAppID, path2)
+		u.So(t, ok, gc.ShouldBeTrue)
+		u.So(
+			t,
+			entry,
+			gc.ShouldResemble,
+			hosting.AssetCacheEntry{
+				FilePath:     path2,
+				LastModified: fileInfo2.ModTime().Unix(),
+				FileSize:     fileInfo2.Size(),
+				FileHash:     mustGenerateFileHash(localPath2),
+			},
+		)
+	})
 }
 
 var jsonAttr = hosting.AssetAttribute{

--- a/hosting/hosting_test.go
+++ b/hosting/hosting_test.go
@@ -30,7 +30,7 @@ func localFileToAssetMetadata(t *testing.T, localPath, rootDir string, assetDesc
 	u.So(t, pathErr, gc.ShouldBeNil)
 	filePath := fmt.Sprintf("/%s", relPath)
 	assetCache := hosting.NewAssetCache()
-	assetMetadata, famErr := hosting.FileToAssetMetadata(appID, localPath, filePath, info, assetDescriptions[filePath], assetCache)
+	assetMetadata, famErr := hosting.FileToAssetMetadata(appID, localPath, filePath, info, assetDescriptions, assetCache)
 	u.So(t, famErr, gc.ShouldBeNil)
 	u.So(t, assetCache.Dirty(), gc.ShouldBeTrue)
 
@@ -46,9 +46,12 @@ func TestListLocalAssetMetadata(t *testing.T) {
 	var testData []hosting.AssetMetadata
 	path0 := "../testdata/full_app/hosting/files/asset_file0.json"
 	path1 := "../testdata/full_app/hosting/files/ships/nostromo.json"
+	path2 := "../testdata/full_app/hosting/files/asset_file1.html"
 	fp0, fErr := filepath.Abs(path0)
 	u.So(t, fErr, gc.ShouldBeNil)
 	fp1, fErr := filepath.Abs(path1)
+	u.So(t, fErr, gc.ShouldBeNil)
+	fp2, fErr := filepath.Abs(path2)
 	u.So(t, fErr, gc.ShouldBeNil)
 
 	rootDir, fErr := filepath.Abs("../testdata/full_app/hosting/files")
@@ -72,8 +75,8 @@ func TestListLocalAssetMetadata(t *testing.T) {
 
 	am0 := localFileToAssetMetadata(t, fp0, rootDir, assetDescriptions)
 	am1 := localFileToAssetMetadata(t, fp1, rootDir, assetDescriptions)
-	testData = append(testData, *am0)
-	testData = append(testData, *am1)
+	am2 := localFileToAssetMetadata(t, fp2, rootDir, assetDescriptions)
+	testData = append(testData, *am0, *am2, *am1)
 
 	u.So(t, fErr, gc.ShouldBeNil)
 	file, err := os.Open(rootDir)

--- a/hosting/models.go
+++ b/hosting/models.go
@@ -5,7 +5,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/10gen/stitch-cli/utils"
 )
@@ -45,14 +44,14 @@ func (amd *AssetMetadata) IsDir() bool {
 }
 
 // NewAssetMetadata is a constructor for AssetMetadata
-func NewAssetMetadata(appID, filePath, fileHash string, fileSize int64, attrs []AssetAttribute) *AssetMetadata {
+func NewAssetMetadata(appID, filePath, fileHash string, fileSize int64, attrs []AssetAttribute, lastModified int64) *AssetMetadata {
 	return &AssetMetadata{
 		AppID:        appID,
 		FilePath:     filePath,
 		FileHash:     fileHash,
 		FileSize:     fileSize,
 		Attrs:        attrs,
-		LastModified: time.Now().Unix(),
+		LastModified: lastModified,
 	}
 }
 

--- a/testdata/full_app/hosting/files/asset_file1.html
+++ b/testdata/full_app/hosting/files/asset_file1.html
@@ -1,0 +1,1 @@
+<html>hi</html>


### PR DESCRIPTION
had to move the asset description lookup into `FileToAssetMetadata`, otherwise the only way to make the tests pass would be to add the same code into `localFileToAssetMetadata` in the test code, but that would defeat the purpose of the test. Probably worth refactoring that test code at some point anyway. 