### PR TITLE
STITCH-3121: Add `--for-source-control` option to export command

### DIFF
--- a/api/stitch_client.go
+++ b/api/stitch_client.go
@@ -16,7 +16,18 @@ import (
 	"github.com/10gen/stitch-cli/models"
 )
 
+// ExportStrategy is the enumeration of possible strategies which can be used
+// when exporting a stitch application
+type ExportStrategy string
+
 const (
+	// ExportStrategyNone will result in no extra configuration into the call to Export
+	ExportStrategyNone ExportStrategy = "none"
+	// ExportStrategyTemplate will result in the `template` querystring parameter getting added to the call to Export
+	ExportStrategyTemplate ExportStrategy = "template"
+	// ExportStrategySourceControl will result in the `source_control` querystring parameter getting added to the call to Export
+	ExportStrategySourceControl ExportStrategy = "source_control"
+
 	authProviderLoginRoute      = adminBaseURL + "/auth/providers/%s/login"
 	appExportRoute              = adminBaseURL + "/groups/%s/apps/%s/export?%s"
 	appImportRoute              = adminBaseURL + "/groups/%s/apps/%s/import"
@@ -60,7 +71,7 @@ type invalidateCachePayload struct {
 // StitchClient represents a Client that can be used to call the Stitch Admin API
 type StitchClient interface {
 	Authenticate(authProvider auth.AuthenticationProvider) (*auth.Response, error)
-	Export(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error)
+	Export(groupID, appID string, strategy ExportStrategy) (string, io.ReadCloser, error)
 	Import(groupID, appID string, appData []byte, strategy string) error
 	Diff(groupID, appID string, appData []byte, strategy string) ([]string, error)
 	FetchAppByGroupIDAndClientAppID(groupID, clientAppID string) (*models.App, error)
@@ -120,11 +131,11 @@ func (sc *basicStitchClient) Authenticate(authProvider auth.AuthenticationProvid
 }
 
 // Export will download a Stitch app as a .zip
-func (sc *basicStitchClient) Export(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+func (sc *basicStitchClient) Export(groupID, appID string, strategy ExportStrategy) (string, io.ReadCloser, error) {
 	url := fmt.Sprintf(appExportRoute, groupID, appID, "")
-	if isTemplated {
+	if strategy == ExportStrategyTemplate {
 		url = fmt.Sprintf(appExportRoute, groupID, appID, "template=true")
-	} else if forSourceControl {
+	} else if strategy == ExportStrategySourceControl {
 		url = fmt.Sprintf(appExportRoute, groupID, appID, "source_control=true")
 	}
 

--- a/commands/export.go
+++ b/commands/export.go
@@ -46,11 +46,12 @@ type ExportCommand struct {
 	writeFileToDirectory func(dest string, data io.Reader) error
 	getAssetAtURL        func(url string) (io.ReadCloser, error)
 
-	flagProjectID      string
-	flagAppID          string
-	flagOutput         string
-	flagAsTemplate     bool
-	flagIncludeHosting bool
+	flagProjectID        string
+	flagAppID            string
+	flagOutput           string
+	flagAsTemplate       bool
+	flagIncludeHosting   bool
+	flagForSourceControl bool
 }
 
 // Help returns long-form help information for this command
@@ -71,6 +72,9 @@ OPTIONS:
   --as-template
 	Indicate that the application should be exported as a template.
 
+	--for-source-control
+	Indicate that the application should be exported for source control.
+
   --include-hosting
 	Download static assets associated with this project` +
 		ec.BaseCommand.Help()
@@ -90,6 +94,7 @@ func (ec *ExportCommand) Run(args []string) int {
 	set.StringVar(&ec.flagOutput, "output", "", "")
 	set.StringVar(&ec.flagOutput, "o", "", "")
 	set.BoolVar(&ec.flagAsTemplate, "as-template", false, "")
+	set.BoolVar(&ec.flagForSourceControl, "for-source-control", false, "")
 	set.BoolVar(&ec.flagIncludeHosting, "include-hosting", false, "")
 
 	if err := ec.BaseCommand.run(args); err != nil {
@@ -140,7 +145,7 @@ func (ec *ExportCommand) run() error {
 			return err
 		}
 	}
-	filename, body, err := stitchClient.Export(app.GroupID, app.ID, ec.flagAsTemplate)
+	filename, body, err := stitchClient.Export(app.GroupID, app.ID, ec.flagAsTemplate, ec.flagForSourceControl)
 	if err != nil {
 		return err
 	}

--- a/commands/export.go
+++ b/commands/export.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/10gen/stitch-cli/api"
 	"github.com/10gen/stitch-cli/models"
 	u "github.com/10gen/stitch-cli/user"
 	"github.com/10gen/stitch-cli/utils"
@@ -72,7 +73,7 @@ OPTIONS:
   --as-template
 	Indicate that the application should be exported as a template.
 
-	--for-source-control
+  --for-source-control
 	Indicate that the application should be exported for source control.
 
   --include-hosting
@@ -145,7 +146,15 @@ func (ec *ExportCommand) run() error {
 			return err
 		}
 	}
-	filename, body, err := stitchClient.Export(app.GroupID, app.ID, ec.flagAsTemplate, ec.flagForSourceControl)
+
+	exportStrategy := api.ExportStrategyNone
+	if ec.flagAsTemplate {
+		exportStrategy = api.ExportStrategyTemplate
+	} else if ec.flagForSourceControl {
+		exportStrategy = api.ExportStrategySourceControl
+	}
+
+	filename, body, err := stitchClient.Export(app.GroupID, app.ID, exportStrategy)
 	if err != nil {
 		return err
 	}

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/10gen/stitch-cli/api"
 	"github.com/10gen/stitch-cli/hosting"
 	"github.com/10gen/stitch-cli/models"
 	"github.com/10gen/stitch-cli/user"
@@ -216,7 +217,7 @@ func TestExportCommand(t *testing.T) {
 								ID:          responseAppID,
 							}, nil
 						},
-						ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+						ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 							u.So(t, groupID, gc.ShouldEqual, tc.ExpectedGroupID)
 							u.So(t, appID, gc.ShouldEqual, responseAppID)
 
@@ -292,8 +293,8 @@ func TestExportCommand(t *testing.T) {
 							ID:          "app-id",
 						}, nil
 					},
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
-						u.So(t, forSourceControl, gc.ShouldBeTrue)
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
+						u.So(t, strategy, gc.ShouldEqual, api.ExportStrategySourceControl)
 						return "", u.NewResponseBody(strings.NewReader("")), nil
 					},
 				}
@@ -314,7 +315,7 @@ func TestExportCommand(t *testing.T) {
 						ID:          "app-id",
 					}, nil
 				},
-				ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+				ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 					return "", nil, fmt.Errorf("oh noes")
 				},
 			}

--- a/commands/import.go
+++ b/commands/import.go
@@ -105,7 +105,7 @@ OPTIONS:
 	The Atlas Project ID.
 
   --strategy [merge|replace] (default: merge)
-	How your app should be imported.	
+	How your app should be imported.
 	merge - import and overwrite existing entities while preserving those that exist on Stitch. Secrets missing will not be lost.
 	replace - like merge but does not preserve entities missing from the local directory's app configuration.
 
@@ -114,7 +114,7 @@ OPTIONS:
 	Upload static assets from "/hosting" directory.
 
   --reset-cdn-cache
-	Invalidate cdn cache for modified files.	
+	Invalidate cdn cache for modified files.
 	` +
 		ic.BaseCommand.Help()
 }
@@ -318,7 +318,7 @@ func (ic *ImportCommand) importApp() error {
 	}
 
 	// re-fetch imported app to sync IDs
-	_, body, err := stitchClient.Export(app.GroupID, app.ID, false)
+	_, body, err := stitchClient.Export(app.GroupID, app.ID, false, false)
 	if err != nil {
 		return errImportAppSyncFailure(err)
 	}

--- a/commands/import.go
+++ b/commands/import.go
@@ -318,7 +318,7 @@ func (ic *ImportCommand) importApp() error {
 	}
 
 	// re-fetch imported app to sync IDs
-	_, body, err := stitchClient.Export(app.GroupID, app.ID, false, false)
+	_, body, err := stitchClient.Export(app.GroupID, app.ID, api.ExportStrategyNone)
 	if err != nil {
 		return errImportAppSyncFailure(err)
 	}

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -40,7 +40,7 @@ func setUpBasicCommand() (*ImportCommand, *cli.MockUi) {
 	}
 
 	mockStitchClient := &u.MockStitchClient{
-		ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+		ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 			return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 		},
 		DiffFn: func(groupID, appID string, appData []byte, strategy string) ([]string, error) {
@@ -89,7 +89,7 @@ func TestImportNewApp(t *testing.T) {
 
 		t.Run("supports creating and importing a new app", func(t *testing.T) {
 			stitchClient := u.MockStitchClient{
-				ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+				ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 					return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 				},
 				CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -145,7 +145,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -170,7 +170,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -195,7 +195,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -223,7 +223,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -286,7 +286,7 @@ func TestImportNewApp(t *testing.T) {
 
 		t.Run("returns an error when an invalid project name is entered", func(t *testing.T) {
 			stitchClient := u.MockStitchClient{
-				ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+				ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 					return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 				},
 				CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -338,7 +338,7 @@ func TestImportNewApp(t *testing.T) {
 		//include multi-region
 		t.Run("supports creating app with non-default location and deployment model", func(t *testing.T) {
 			stitchClient := u.MockStitchClient{
-				ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+				ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 					return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 				},
 				CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -392,7 +392,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/simple_app_with_deployment_config"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -414,7 +414,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/simple_app_with_deployment_config"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -436,7 +436,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 1,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -458,7 +458,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -571,7 +571,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             append([]string{"--path=../testdata/full_app"}, validArgs...),
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -594,7 +594,7 @@ func TestImportCommand(t *testing.T) {
 				ExpectedExitCode: 1,
 				ExpectedError:    "oh no failed to fetch app",
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", nil, fmt.Errorf("oh no")
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -613,7 +613,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             append([]string{"--path=../testdata/simple_app_empty_stitch_json"}, validArgs...),
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(strings.NewReader("export response")), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -655,7 +655,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             []string{"--path=../testdata/simple_app_with_instance_data"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(strings.NewReader("export response")), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -677,7 +677,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             []string{"--path=../testdata/simple_app_with_instance_data", "--project-id=myprojectid"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(strings.NewReader("export response")), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -703,7 +703,7 @@ func TestImportCommand(t *testing.T) {
 				ExpectedExitCode: 0,
 				WorkingDirectory: "../testdata/simple_app_with_instance_data",
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(strings.NewReader("export response")), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -726,7 +726,7 @@ func TestImportCommand(t *testing.T) {
 				ExpectedExitCode: 1,
 				ExpectedError:    "failed to sync app",
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", nil, fmt.Errorf("oh no")
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -765,7 +765,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             append([]string{"--path=../testdata/full_app", "--include-hosting"}, validArgs...),
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -790,7 +790,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             append([]string{"--path=../testdata/full_app", "--include-hosting", "--reset-cdn-cache"}, validArgs...),
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -870,7 +870,7 @@ func TestImportCommand(t *testing.T) {
 						mockUI.InputReader = strings.NewReader("y\n")
 						importCommand.workingDirectory = tc.WorkingDirectory
 						mockStitchClient := &u.MockStitchClient{
-							ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+							ExportFn: func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 								return "", u.NewResponseBody(strings.NewReader("export response")), nil
 							},
 							ImportFn: func(groupID, appID string, appData []byte, strategy string) error {

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -40,7 +40,7 @@ func setUpBasicCommand() (*ImportCommand, *cli.MockUi) {
 	}
 
 	mockStitchClient := &u.MockStitchClient{
-		ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+		ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 			return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 		},
 		DiffFn: func(groupID, appID string, appData []byte, strategy string) ([]string, error) {
@@ -89,7 +89,7 @@ func TestImportNewApp(t *testing.T) {
 
 		t.Run("supports creating and importing a new app", func(t *testing.T) {
 			stitchClient := u.MockStitchClient{
-				ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+				ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 					return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 				},
 				CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -145,7 +145,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -170,7 +170,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -195,7 +195,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -223,7 +223,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -286,7 +286,7 @@ func TestImportNewApp(t *testing.T) {
 
 		t.Run("returns an error when an invalid project name is entered", func(t *testing.T) {
 			stitchClient := u.MockStitchClient{
-				ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+				ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 					return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 				},
 				CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -338,7 +338,7 @@ func TestImportNewApp(t *testing.T) {
 		//include multi-region
 		t.Run("supports creating app with non-default location and deployment model", func(t *testing.T) {
 			stitchClient := u.MockStitchClient{
-				ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+				ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 					return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 				},
 				CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -392,7 +392,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/simple_app_with_deployment_config"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -414,7 +414,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/simple_app_with_deployment_config"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -436,7 +436,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 1,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -458,7 +458,7 @@ func TestImportNewApp(t *testing.T) {
 				Args:             []string{"--path=../testdata/new_app"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					CreateEmptyAppFn: func(groupID, appName, locationName, deploymentModelName string) (*models.App, error) {
@@ -571,7 +571,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             append([]string{"--path=../testdata/full_app"}, validArgs...),
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -594,7 +594,7 @@ func TestImportCommand(t *testing.T) {
 				ExpectedExitCode: 1,
 				ExpectedError:    "oh no failed to fetch app",
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", nil, fmt.Errorf("oh no")
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -613,7 +613,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             append([]string{"--path=../testdata/simple_app_empty_stitch_json"}, validArgs...),
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(strings.NewReader("export response")), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -655,7 +655,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             []string{"--path=../testdata/simple_app_with_instance_data"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(strings.NewReader("export response")), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -677,7 +677,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             []string{"--path=../testdata/simple_app_with_instance_data", "--project-id=myprojectid"},
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(strings.NewReader("export response")), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -703,7 +703,7 @@ func TestImportCommand(t *testing.T) {
 				ExpectedExitCode: 0,
 				WorkingDirectory: "../testdata/simple_app_with_instance_data",
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(strings.NewReader("export response")), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -726,7 +726,7 @@ func TestImportCommand(t *testing.T) {
 				ExpectedExitCode: 1,
 				ExpectedError:    "failed to sync app",
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", nil, fmt.Errorf("oh no")
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -765,7 +765,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             append([]string{"--path=../testdata/full_app", "--include-hosting"}, validArgs...),
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -790,7 +790,7 @@ func TestImportCommand(t *testing.T) {
 				Args:             append([]string{"--path=../testdata/full_app", "--include-hosting", "--reset-cdn-cache"}, validArgs...),
 				ExpectedExitCode: 0,
 				StitchClient: u.MockStitchClient{
-					ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+					ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 						return "", u.NewResponseBody(bytes.NewReader([]byte{})), nil
 					},
 					ImportFn: func(groupID, appID string, appData []byte, strategy string) error {
@@ -870,7 +870,7 @@ func TestImportCommand(t *testing.T) {
 						mockUI.InputReader = strings.NewReader("y\n")
 						importCommand.workingDirectory = tc.WorkingDirectory
 						mockStitchClient := &u.MockStitchClient{
-							ExportFn: func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+							ExportFn: func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 								return "", u.NewResponseBody(strings.NewReader("export response")), nil
 							},
 							ImportFn: func(groupID, appID string, appData []byte, strategy string) error {

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -211,7 +210,7 @@ type MockStitchClient struct {
 	MoveAssetFn                       func(groupID, appID, fromPath, toPath string) error
 	DeleteAssetFn                     func(groupID, appID, path string) error
 	SetAssetAttributesFn              func(groupID, appID, path string, attributes ...hosting.AssetAttribute) error
-	ExportFn                          func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error)
+	ExportFn                          func(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error)
 	ExportFnCalls                     [][]string
 	ImportFn                          func(groupID, appID string, appData []byte, strategy string) error
 	ImportFnCalls                     [][]string
@@ -225,10 +224,10 @@ func (msc *MockStitchClient) Authenticate(authProvider auth.AuthenticationProvid
 }
 
 // Export will download a Stitch app as a .zip
-func (msc *MockStitchClient) Export(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
+func (msc *MockStitchClient) Export(groupID, appID string, strategy api.ExportStrategy) (string, io.ReadCloser, error) {
 	if msc.ExportFn != nil {
-		msc.ExportFnCalls = append(msc.ExportFnCalls, []string{groupID, appID, strconv.FormatBool(isTemplated)})
-		return msc.ExportFn(groupID, appID, isTemplated, forSourceControl)
+		msc.ExportFnCalls = append(msc.ExportFnCalls, []string{groupID, appID, string(strategy)})
+		return msc.ExportFn(groupID, appID, strategy)
 	}
 
 	return "", nil, nil

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -211,7 +211,7 @@ type MockStitchClient struct {
 	MoveAssetFn                       func(groupID, appID, fromPath, toPath string) error
 	DeleteAssetFn                     func(groupID, appID, path string) error
 	SetAssetAttributesFn              func(groupID, appID, path string, attributes ...hosting.AssetAttribute) error
-	ExportFn                          func(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error)
+	ExportFn                          func(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error)
 	ExportFnCalls                     [][]string
 	ImportFn                          func(groupID, appID string, appData []byte, strategy string) error
 	ImportFnCalls                     [][]string
@@ -225,10 +225,10 @@ func (msc *MockStitchClient) Authenticate(authProvider auth.AuthenticationProvid
 }
 
 // Export will download a Stitch app as a .zip
-func (msc *MockStitchClient) Export(groupID, appID string, isTemplated bool) (string, io.ReadCloser, error) {
+func (msc *MockStitchClient) Export(groupID, appID string, isTemplated, forSourceControl bool) (string, io.ReadCloser, error) {
 	if msc.ExportFn != nil {
 		msc.ExportFnCalls = append(msc.ExportFnCalls, []string{groupID, appID, strconv.FormatBool(isTemplated)})
-		return msc.ExportFn(groupID, appID, isTemplated)
+		return msc.ExportFn(groupID, appID, isTemplated, forSourceControl)
 	}
 
 	return "", nil, nil


### PR DESCRIPTION
This modifies the call to stitch to include the `source_control` querystring parameter which will cause it to export a version of the app which is source control safe.