### PR TITLE
STITCH-3614: Fix secrets help documentation

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -22,8 +22,7 @@ import (
 )
 
 const (
-	flagProjectIDName = "project-id"
-	flagAppIDName     = "app-id"
+	flagAppIDName = "app-id"
 )
 
 var (

--- a/commands/project_command.go
+++ b/commands/project_command.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"github.com/mitchellh/cli"
+)
+
+const (
+	flagProjectIDName = "project-id"
+)
+
+// NewProjectCommand returns a new *ProjectCommand
+func NewProjectCommand(name string, ui cli.Ui) *ProjectCommand {
+	return &ProjectCommand{
+		BaseCommand: &BaseCommand{
+			Name: name,
+			UI:   ui,
+		},
+	}
+}
+
+// ProjectCommand handles the parsing and execution of an Atlas project-based command.
+type ProjectCommand struct {
+	*BaseCommand
+
+	flagProjectID string
+}
+
+func (pc *ProjectCommand) run(args []string) error {
+	if pc.FlagSet == nil {
+		pc.NewFlagSet()
+	}
+
+	pc.FlagSet.StringVar(&pc.flagProjectID, flagProjectIDName, "", "")
+
+	if err := pc.BaseCommand.run(args); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Help defines help documentation for parameters that apply to project commands
+func (pc *ProjectCommand) Help() string {
+	return `
+
+  --project-id [string]
+	The Atlas Project ID.` +
+		pc.BaseCommand.Help()
+}

--- a/commands/secrets_test.go
+++ b/commands/secrets_test.go
@@ -13,30 +13,32 @@ import (
 	gc "github.com/smartystreets/goconvey/convey"
 )
 
+type mockClientFunctions struct {
+	listSecretsFn        func(groupID, appID string) ([]secrets.Secret, error)
+	addSecretFn          func(groupID, appID string, secret secrets.Secret) error
+	updateSecretByIDFn   func(groupID, appID, secretID, secretValue string) error
+	updateSecretByNameFn func(groupID, appID, secretName, secretValue string) error
+	removeSecretByIDFn   func(groupID, appID, secretID string) error
+	removeSecretByNameFn func(groupID, appID, secretName string) error
+}
+
 func setUpBasicSecretsCommand(
-	listSecretsFn func(groupID, appID string) ([]secrets.Secret, error),
-	addSecretFn func(groupID, appID string, secret secrets.Secret) error,
-	updateSecretByIDFn func(groupID, appID, secretID, secretValue string) error,
-	updateSecretByNameFn func(groupID, appID, secretName, secretValue string) error,
-	removeSecretByIDFn func(groupID, appID, secretID string) error,
-	removeSecretByNameFn func(groupID, appID, secretName string) error,
-) (*SecretsCommand, *cli.MockUi) {
-	mockUI := cli.NewMockUi()
-	cmd, err := NewSecretsCommandFactory(mockUI)()
-	if err != nil {
-		panic(err)
+	baseCommand *SecretsBaseCommand,
+	mcf *mockClientFunctions,
+) {
+	baseCommand.storage = u.NewEmptyStorage()
+
+	if mcf == nil {
+		mcf = &mockClientFunctions{}
 	}
 
-	secretsCommand := cmd.(*SecretsCommand)
-	secretsCommand.storage = u.NewEmptyStorage()
-
 	mockStitchClient := &u.MockStitchClient{
-		ListSecretsFn:        listSecretsFn,
-		AddSecretFn:          addSecretFn,
-		UpdateSecretByIDFn:   updateSecretByIDFn,
-		UpdateSecretByNameFn: updateSecretByNameFn,
-		RemoveSecretByIDFn:   removeSecretByIDFn,
-		RemoveSecretByNameFn: removeSecretByNameFn,
+		ListSecretsFn:        mcf.listSecretsFn,
+		AddSecretFn:          mcf.addSecretFn,
+		UpdateSecretByIDFn:   mcf.updateSecretByIDFn,
+		UpdateSecretByNameFn: mcf.updateSecretByNameFn,
+		RemoveSecretByIDFn:   mcf.removeSecretByIDFn,
+		RemoveSecretByNameFn: mcf.removeSecretByNameFn,
 		FetchAppByClientAppIDFn: func(clientAppID string) (*models.App, error) {
 			return &models.App{
 				GroupID: "group-id",
@@ -44,8 +46,7 @@ func setUpBasicSecretsCommand(
 			}, nil
 		},
 	}
-	secretsCommand.stitchClient = mockStitchClient
-	return secretsCommand, mockUI
+	baseCommand.stitchClient = mockStitchClient
 }
 
 func TestSecretsCommand(t *testing.T) {
@@ -57,32 +58,56 @@ func TestSecretsCommand(t *testing.T) {
 	validRemoveByNameArgs := []string{"--app-id=my-app-abcdef", "--secret-name=thisisaname"}
 
 	t.Run("listing a secret should require the user to be logged in", func(t *testing.T) {
-		secretsCommand, mockUI := setUpBasicSecretsCommand(nil, nil, nil, nil, nil, nil)
-		exitCode := secretsCommand.Run(append([]string{"list"}, validListArgs...))
+		mockUI := cli.NewMockUi()
+		cmd, err := NewSecretsListCommandFactory(mockUI)()
+		u.So(t, err, gc.ShouldBeNil)
+
+		listCommand := cmd.(*SecretsListCommand)
+		setUpBasicSecretsCommand(listCommand.SecretsBaseCommand, nil)
+
+		exitCode := listCommand.Run(validListArgs)
 		u.So(t, exitCode, gc.ShouldEqual, 1)
 
 		u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, user.ErrNotLoggedIn.Error())
 	})
 
 	t.Run("adding a secret should require the user to be logged in", func(t *testing.T) {
-		secretsCommand, mockUI := setUpBasicSecretsCommand(nil, nil, nil, nil, nil, nil)
-		exitCode := secretsCommand.Run(append([]string{"add"}, validAddArgs...))
+		mockUI := cli.NewMockUi()
+		cmd, err := NewSecretsAddCommandFactory(mockUI)()
+		u.So(t, err, gc.ShouldBeNil)
+
+		addCommand := cmd.(*SecretsAddCommand)
+		setUpBasicSecretsCommand(addCommand.SecretsBaseCommand, nil)
+
+		exitCode := addCommand.Run(validAddArgs)
 		u.So(t, exitCode, gc.ShouldEqual, 1)
 
 		u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, user.ErrNotLoggedIn.Error())
 	})
 
 	t.Run("updating a secret should require the user to be logged in", func(t *testing.T) {
-		secretsCommand, mockUI := setUpBasicSecretsCommand(nil, nil, nil, nil, nil, nil)
-		exitCode := secretsCommand.Run(append([]string{"update"}, validUpdateByIDArgs...))
+		mockUI := cli.NewMockUi()
+		cmd, err := NewSecretsUpdateCommandFactory(mockUI)()
+		u.So(t, err, gc.ShouldBeNil)
+
+		updateCommand := cmd.(*SecretsUpdateCommand)
+		setUpBasicSecretsCommand(updateCommand.SecretsBaseCommand, nil)
+
+		exitCode := updateCommand.Run(validUpdateByIDArgs)
 		u.So(t, exitCode, gc.ShouldEqual, 1)
 
 		u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, user.ErrNotLoggedIn.Error())
 	})
 
 	t.Run("removing a secret should require the user to be logged in", func(t *testing.T) {
-		secretsCommand, mockUI := setUpBasicSecretsCommand(nil, nil, nil, nil, nil, nil)
-		exitCode := secretsCommand.Run(append([]string{"remove"}, validRemoveByIDArgs...))
+		mockUI := cli.NewMockUi()
+		cmd, err := NewSecretsRemoveCommandFactory(mockUI)()
+		u.So(t, err, gc.ShouldBeNil)
+
+		removeCommand := cmd.(*SecretsRemoveCommand)
+		setUpBasicSecretsCommand(removeCommand.SecretsBaseCommand, nil)
+
+		exitCode := removeCommand.Run(validRemoveByIDArgs)
 		u.So(t, exitCode, gc.ShouldEqual, 1)
 
 		u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, user.ErrNotLoggedIn.Error())
@@ -90,187 +115,273 @@ func TestSecretsCommand(t *testing.T) {
 
 	t.Run("when the user is logged in", func(t *testing.T) {
 		setup := func(
-			listSecretsFn func(appID, groupID string) ([]secrets.Secret, error),
-			addSecretsFn func(appID, groupID string, secret secrets.Secret) error,
-			updateSecretByIDFn func(appID, groupID, secretID, secretValue string) error,
-			updateSecretsByNameFn func(appID, groupID, secretName, secretValue string) error,
-			removeSecretByIDFn func(appID, groupID, secretID string) error,
-			removeSecretsByNameFn func(appID, groupID, secretName string) error,
-		) (*SecretsCommand, *cli.MockUi) {
-			secretsCommand, mockUI := setUpBasicSecretsCommand(
-				listSecretsFn,
-				addSecretsFn,
-				updateSecretByIDFn,
-				updateSecretsByNameFn,
-				removeSecretByIDFn,
-				removeSecretsByNameFn,
-			)
-
-			secretsCommand.user = &user.User{
+			baseCommand *SecretsBaseCommand,
+			mcf *mockClientFunctions,
+		) {
+			setUpBasicSecretsCommand(baseCommand, mcf)
+			baseCommand.user = &user.User{
 				APIKey:      "my-api-key",
 				AccessToken: u.GenerateValidAccessToken(),
 			}
-
-			return secretsCommand, mockUI
 		}
 
-		t.Run("it fails if there is no sub command", func(t *testing.T) {
-			secretsCommand, _ := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{}, validAddArgs...))
-			u.So(t, exitCode, gc.ShouldEqual, 127)
-		})
-
-		t.Run("it fails if there is an invalid sub command", func(t *testing.T) {
-			secretsCommand, _ := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"invalid"}, validAddArgs...))
-			u.So(t, exitCode, gc.ShouldEqual, 127)
-		})
-
 		t.Run("adding a secret fails if the secret name is missing", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"add", "--app-id=my-app-abcdef", "--value=bar"}))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsAddCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			addCommand := cmd.(*SecretsAddCommand)
+			setup(addCommand.SecretsBaseCommand, nil)
+
+			exitCode := addCommand.Run([]string{"--app-id=my-app-abcdef", "--value=bar"})
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "is required")
 		})
 
 		t.Run("adding a secret fails if the secret value is missing", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"add", "--app-id=my-app-abcdef", "--name=foo"}))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsAddCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			addCommand := cmd.(*SecretsAddCommand)
+			setup(addCommand.SecretsBaseCommand, nil)
+
+			exitCode := addCommand.Run([]string{"--app-id=my-app-abcdef", "--name=foo"})
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "is required")
 		})
 
 		t.Run("removing a secret fails if the secret id and name are missing", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"remove", "--app-id=my-app-abcdef"}))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsRemoveCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			removeCommand := cmd.(*SecretsRemoveCommand)
+			setup(removeCommand.SecretsBaseCommand, nil)
+
+			exitCode := removeCommand.Run([]string{"--app-id=my-app-abcdef"})
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "is required")
 		})
 
 		t.Run("listing a secret fails if the listing method fails", func(t *testing.T) {
-			secretsCommand, mockUI := setup(func(appID, groupID string) ([]secrets.Secret, error) {
-				return nil, errors.New("oopsies")
-			}, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"list"}, validListArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsListCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			listCommand := cmd.(*SecretsListCommand)
+			setup(
+				listCommand.SecretsBaseCommand,
+				&mockClientFunctions{
+					listSecretsFn: func(appID, groupID string) ([]secrets.Secret, error) {
+						return nil, errors.New("oopsies")
+					},
+				},
+			)
+
+			exitCode := listCommand.Run([]string{"--app-id=my-app-abcdef"})
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "oopsies")
 		})
 
 		t.Run("adding a secret fails if adding the secret fails", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, func(appID, groupID string, secret secrets.Secret) error {
-				return errors.New("oopsies")
-			}, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"add"}, validAddArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsAddCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			addCommand := cmd.(*SecretsAddCommand)
+			setup(addCommand.SecretsBaseCommand, &mockClientFunctions{
+				addSecretFn: func(appID, groupID string, secret secrets.Secret) error {
+					return errors.New("oopsies")
+				},
+			})
+
+			exitCode := addCommand.Run(validAddArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "oopsies")
 		})
 
-		t.Run("updating a secret by id fails if removing the secret fails", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, func(appID, groupID, secretID, secretValue string) error {
-				return errors.New("oopsies")
-			}, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"update"}, validUpdateByIDArgs...))
+		t.Run("updating a secret by id fails if updating the secret fails", func(t *testing.T) {
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsUpdateCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			updateCommand := cmd.(*SecretsUpdateCommand)
+			setup(updateCommand.SecretsBaseCommand, &mockClientFunctions{
+				updateSecretByIDFn: func(appID, groupID, secretID, secretValue string) error {
+					return errors.New("oopsies")
+				},
+			})
+			exitCode := updateCommand.Run(validUpdateByIDArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "oopsies")
 		})
 
-		t.Run("updating a secret by name fails if removing the secret fails", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, func(appID, groupID, secretName, secretValue string) error {
-				return errors.New("oopsies")
-			}, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"update"}, validUpdateByNameArgs...))
+		t.Run("updating a secret by name fails if updating the secret fails", func(t *testing.T) {
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsUpdateCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			updateCommand := cmd.(*SecretsUpdateCommand)
+			setup(updateCommand.SecretsBaseCommand, &mockClientFunctions{
+				updateSecretByNameFn: func(appID, groupID, secretName, secretValue string) error {
+					return errors.New("oopsies")
+				},
+			})
+			exitCode := updateCommand.Run(validUpdateByNameArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "oopsies")
 		})
 
 		t.Run("removing a secret by id fails if removing the secret fails", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, func(appID, groupID, secretID string) error {
-				return errors.New("oopsies")
-			}, nil)
-			exitCode := secretsCommand.Run(append([]string{"remove"}, validRemoveByIDArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsRemoveCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			removeCommand := cmd.(*SecretsRemoveCommand)
+			setup(removeCommand.SecretsBaseCommand, &mockClientFunctions{
+				removeSecretByIDFn: func(appID, groupID, secretID string) error {
+					return errors.New("oopsies")
+				},
+			})
+			exitCode := removeCommand.Run(validRemoveByIDArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "oopsies")
 		})
 
 		t.Run("removing a secret by name fails if removing the secret fails", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, func(appID, groupID, secretID string) error {
-				return errors.New("oopsies")
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsRemoveCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			removeCommand := cmd.(*SecretsRemoveCommand)
+			setup(removeCommand.SecretsBaseCommand, &mockClientFunctions{
+				removeSecretByNameFn: func(appID, groupID, secretName string) error {
+					return errors.New("oopsies")
+				},
 			})
-			exitCode := secretsCommand.Run(append([]string{"remove"}, validRemoveByNameArgs...))
+			exitCode := removeCommand.Run(validRemoveByNameArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 1)
 			u.So(t, mockUI.ErrorWriter.String(), gc.ShouldContainSubstring, "oopsies")
 		})
 
 		t.Run("it passes the correct flags to AddSecret", func(t *testing.T) {
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsAddCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
 			var secretName string
 			var secretValue string
-			secretsCommand, _ := setup(nil, func(appID, groupID string, secret secrets.Secret) error {
-				secretName = secret.Name
-				secretValue = secret.Value
-				return nil
-			}, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"add"}, validAddArgs...))
+			addCommand := cmd.(*SecretsAddCommand)
+			setup(addCommand.SecretsBaseCommand, &mockClientFunctions{
+				addSecretFn: func(appID, groupID string, secret secrets.Secret) error {
+					secretName = secret.Name
+					secretValue = secret.Value
+					return nil
+				},
+			})
+			exitCode := addCommand.Run(validAddArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, secretName, gc.ShouldEqual, "foo")
 			u.So(t, secretValue, gc.ShouldEqual, "bar")
 		})
 
 		t.Run("it passes the correct flags to UpdateSecretByID", func(t *testing.T) {
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsUpdateCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
 			var secretID string
-			secretsCommand, _ := setup(nil, nil, func(appID, groupID, id, value string) error {
-				secretID = id
-				return nil
-			}, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"update"}, validUpdateByIDArgs...))
+			updateCommand := cmd.(*SecretsUpdateCommand)
+			setup(updateCommand.SecretsBaseCommand, &mockClientFunctions{
+				updateSecretByIDFn: func(appID, groupID, id, value string) error {
+					secretID = id
+					return nil
+				},
+			})
+			exitCode := updateCommand.Run(validUpdateByIDArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, secretID, gc.ShouldEqual, "thisisanid")
 		})
 
 		t.Run("it passes the correct flags to UpdateSecretByName", func(t *testing.T) {
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsUpdateCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
 			var secretName string
-			secretsCommand, _ := setup(nil, nil, nil, func(appID, groupID, name, value string) error {
-				secretName = name
-				return nil
-			}, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"update"}, validUpdateByNameArgs...))
+			updateCommand := cmd.(*SecretsUpdateCommand)
+			setup(updateCommand.SecretsBaseCommand, &mockClientFunctions{
+				updateSecretByNameFn: func(appID, groupID, name, value string) error {
+					secretName = name
+					return nil
+				},
+			})
+			exitCode := updateCommand.Run(validUpdateByNameArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, secretName, gc.ShouldEqual, "thisisaname")
 		})
 
 		t.Run("it passes the correct flags to RemoveSecretByID", func(t *testing.T) {
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsRemoveCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			removeCommand := cmd.(*SecretsRemoveCommand)
 			var secretID string
-			secretsCommand, _ := setup(nil, nil, nil, nil, func(appID, groupID, id string) error {
-				secretID = id
-				return nil
-			}, nil)
-			exitCode := secretsCommand.Run(append([]string{"remove"}, validRemoveByIDArgs...))
+			setup(removeCommand.SecretsBaseCommand, &mockClientFunctions{
+				removeSecretByIDFn: func(appID, groupID, id string) error {
+					secretID = id
+					return nil
+				},
+			})
+			exitCode := removeCommand.Run(validRemoveByIDArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, secretID, gc.ShouldEqual, "thisisanid")
 		})
 
 		t.Run("it passes the correct flags to RemoveSecretByName", func(t *testing.T) {
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsRemoveCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			removeCommand := cmd.(*SecretsRemoveCommand)
 			var secretName string
-			secretsCommand, _ := setup(nil, nil, nil, nil, nil, func(appID, groupID, name string) error {
-				secretName = name
-				return nil
+			setup(removeCommand.SecretsBaseCommand, &mockClientFunctions{
+				removeSecretByNameFn: func(appID, groupID, name string) error {
+					secretName = name
+					return nil
+				},
 			})
-			exitCode := secretsCommand.Run(append([]string{"remove"}, validRemoveByNameArgs...))
+			exitCode := removeCommand.Run(validRemoveByNameArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, secretName, gc.ShouldEqual, "thisisaname")
 		})
 
 		t.Run("listing secrets works when there are none", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"list"}, validListArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsListCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			listCommand := cmd.(*SecretsListCommand)
+			setup(listCommand.SecretsBaseCommand, nil)
+			exitCode := listCommand.Run(validListArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, mockUI.OutputWriter.String(), gc.ShouldContainSubstring, "No secrets found for this app")
 		})
 
 		t.Run("listing secrets works", func(t *testing.T) {
-			secretsCommand, mockUI := setup(func(appID, groupID string) ([]secrets.Secret, error) {
-				return []secrets.Secret{{ID: "123", Name: "hello", Value: "there"}}, nil
-			}, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"list"}, validListArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsListCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			listCommand := cmd.(*SecretsListCommand)
+			setup(listCommand.SecretsBaseCommand, &mockClientFunctions{
+				listSecretsFn: func(appID, groupID string) ([]secrets.Secret, error) {
+					return []secrets.Secret{{ID: "123", Name: "hello", Value: "there"}}, nil
+				},
+			})
+			exitCode := listCommand.Run(validListArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, mockUI.OutputWriter.String(), gc.ShouldContainSubstring, "123")
 			u.So(t, mockUI.OutputWriter.String(), gc.ShouldContainSubstring, "hello")
@@ -278,36 +389,66 @@ func TestSecretsCommand(t *testing.T) {
 		})
 
 		t.Run("adding a secret works", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"add"}, validAddArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsAddCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			addCommand := cmd.(*SecretsAddCommand)
+			setup(addCommand.SecretsBaseCommand, nil)
+
+			exitCode := addCommand.Run(validAddArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, mockUI.OutputWriter.String(), gc.ShouldContainSubstring, "New secret created")
 		})
 
 		t.Run("updating a secret by id works", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"update"}, validUpdateByIDArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsUpdateCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			updateCommand := cmd.(*SecretsUpdateCommand)
+			setup(updateCommand.SecretsBaseCommand, nil)
+
+			exitCode := updateCommand.Run(validUpdateByIDArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, mockUI.OutputWriter.String(), gc.ShouldContainSubstring, "Secret updated: thisisanid")
 		})
 
 		t.Run("updating a secret by name works", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"update"}, validUpdateByNameArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsUpdateCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			updateCommand := cmd.(*SecretsUpdateCommand)
+			setup(updateCommand.SecretsBaseCommand, nil)
+
+			exitCode := updateCommand.Run(validUpdateByNameArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, mockUI.OutputWriter.String(), gc.ShouldContainSubstring, "Secret updated: thisisaname")
 		})
 
 		t.Run("removing a secret by id works", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"remove"}, validRemoveByIDArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsRemoveCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			removeCommand := cmd.(*SecretsRemoveCommand)
+			setup(removeCommand.SecretsBaseCommand, nil)
+
+			exitCode := removeCommand.Run(validRemoveByIDArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, mockUI.OutputWriter.String(), gc.ShouldContainSubstring, "Secret removed: thisisanid")
 		})
 
 		t.Run("removing a secret by name works", func(t *testing.T) {
-			secretsCommand, mockUI := setup(nil, nil, nil, nil, nil, nil)
-			exitCode := secretsCommand.Run(append([]string{"remove"}, validRemoveByNameArgs...))
+			mockUI := cli.NewMockUi()
+			cmd, err := NewSecretsRemoveCommandFactory(mockUI)()
+			u.So(t, err, gc.ShouldBeNil)
+
+			removeCommand := cmd.(*SecretsRemoveCommand)
+			setup(removeCommand.SecretsBaseCommand, nil)
+
+			exitCode := removeCommand.Run(validRemoveByNameArgs)
 			u.So(t, exitCode, gc.ShouldEqual, 0)
 			u.So(t, mockUI.OutputWriter.String(), gc.ShouldContainSubstring, "Secret removed: thisisaname")
 		})

--- a/main.go
+++ b/main.go
@@ -22,13 +22,17 @@ func main() {
 	}
 
 	c.Commands = map[string]cli.CommandFactory{
-		"whoami":  commands.NewWhoamiCommandFactory(ui),
-		"login":   commands.NewLoginCommandFactory(ui),
-		"logout":  commands.NewLogoutCommandFactory(ui),
-		"export":  commands.NewExportCommandFactory(ui),
-		"import":  commands.NewImportCommandFactory(ui),
-		"diff":    commands.NewDiffCommandFactory(ui),
-		"secrets": commands.NewSecretsCommandFactory(ui),
+		"whoami":         commands.NewWhoamiCommandFactory(ui),
+		"login":          commands.NewLoginCommandFactory(ui),
+		"logout":         commands.NewLogoutCommandFactory(ui),
+		"export":         commands.NewExportCommandFactory(ui),
+		"import":         commands.NewImportCommandFactory(ui),
+		"diff":           commands.NewDiffCommandFactory(ui),
+		"secrets":        commands.NewSecretsCommandFactory(ui),
+		"secrets list":   commands.NewSecretsListCommandFactory(ui),
+		"secrets add":    commands.NewSecretsAddCommandFactory(ui),
+		"secrets update": commands.NewSecretsUpdateCommandFactory(ui),
+		"secrets remove": commands.NewSecretsRemoveCommandFactory(ui),
 	}
 
 	exitStatus, err := c.Run()


### PR DESCRIPTION
* Update secrets commands so that subcommand documentation works
* Add base command structs for shared functionality

Note, changes here made due to the fact that secrets subcommand help documentation did not work. For example, `stitch-cli secrets add -h` only responded with the root `stitch-cli secrets` help documentation, which did not include parameter names, etc.