### PR TITLE
STITCH-3847: Stitch CLI import include hosting failing on Windows

### DIFF
--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -155,7 +156,7 @@ func TestExportCommand(t *testing.T) {
 				},
 				{
 					Description:         "it writes response data to an expanded home directory output path using the '--output' flag",
-					ExpectedDestination: homeDir + "/my_app",
+					ExpectedDestination: homeDir + string(os.PathSeparator) + "my_app",
 					Args:                []string{`--app-id=` + appID, `--output=~/my_app`},
 
 					ExpectedGroupID:               "group-id",
@@ -171,7 +172,7 @@ func TestExportCommand(t *testing.T) {
 				},
 				{
 					Description:         "it writes response data to an expanded home directory output path using the '-o' flag",
-					ExpectedDestination: homeDir + "/my_app",
+					ExpectedDestination: homeDir + string(os.PathSeparator) + "my_app",
 					Args:                []string{`--app-id=` + appID, `-o`, `~/my_app`},
 
 					ExpectedGroupID:               "group-id",
@@ -179,7 +180,7 @@ func TestExportCommand(t *testing.T) {
 				},
 				{
 					Description:          "it writes response data to the default directory and includes hosting assets",
-					ExpectedDestination:  homeDir + "/my_app",
+					ExpectedDestination:  homeDir + string(os.PathSeparator) + "my_app",
 					Args:                 []string{`--app-id=` + appID, `--include-hosting=true`, `--output=~/my_app`},
 					ExpectedMetadataFile: expectedMetadataFile,
 

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -156,7 +156,7 @@ func TestExportCommand(t *testing.T) {
 				},
 				{
 					Description:         "it writes response data to an expanded home directory output path using the '--output' flag",
-					ExpectedDestination: homeDir + string(os.PathSeparator) + "my_app",
+					ExpectedDestination: fmt.Sprintf("%s%smy_app", homeDir, string(os.PathSeparator)),
 					Args:                []string{`--app-id=` + appID, `--output=~/my_app`},
 
 					ExpectedGroupID:               "group-id",
@@ -172,7 +172,7 @@ func TestExportCommand(t *testing.T) {
 				},
 				{
 					Description:         "it writes response data to an expanded home directory output path using the '-o' flag",
-					ExpectedDestination: homeDir + string(os.PathSeparator) + "my_app",
+					ExpectedDestination: fmt.Sprintf("%s%smy_app", homeDir, string(os.PathSeparator)),
 					Args:                []string{`--app-id=` + appID, `-o`, `~/my_app`},
 
 					ExpectedGroupID:               "group-id",
@@ -180,7 +180,7 @@ func TestExportCommand(t *testing.T) {
 				},
 				{
 					Description:          "it writes response data to the default directory and includes hosting assets",
-					ExpectedDestination:  homeDir + string(os.PathSeparator) + "my_app",
+					ExpectedDestination:  fmt.Sprintf("%s%smy_app", homeDir, string(os.PathSeparator)),
 					Args:                 []string{`--app-id=` + appID, `--include-hosting=true`, `--output=~/my_app`},
 					ExpectedMetadataFile: expectedMetadataFile,
 

--- a/hosting/hosting.go
+++ b/hosting/hosting.go
@@ -46,7 +46,7 @@ func buildAssetMetadata(appID string, assetMetadata *[]AssetMetadata, rootDir st
 			if pathErr != nil {
 				return pathErr
 			}
-			assetPath := fmt.Sprintf("/%s", strings.ReplaceAll(relPath, "\\", "/"))
+			assetPath := fmt.Sprintf("/%s", strings.ReplaceAll(relPath, string(os.PathSeparator), "/"))
 
 			var desc *AssetDescription
 			if assetDescriptions != nil {
@@ -128,7 +128,7 @@ func MetadataFileToAssetDescriptions(path string) (map[string]AssetDescription, 
 
 	descM := make(map[string]AssetDescription, len(descs))
 	for _, desc := range descs {
-		descFilePath := strings.ReplaceAll(desc.FilePath, "\\", "/")
+		descFilePath := strings.ReplaceAll(desc.FilePath, string(os.PathSeparator), "/")
 		descM[descFilePath] = desc
 	}
 

--- a/hosting/hosting.go
+++ b/hosting/hosting.go
@@ -181,7 +181,7 @@ func DiffAssetMetadata(local, remote []AssetMetadata, merge bool) *AssetMetadata
 	remoteAM := AssetsMetadata(remote).MapByPath()
 
 	// Ignore the root directory
-	delete(remoteAM, "/")
+	delete(remoteAM, string(os.PathSeparator))
 
 	for _, lAM := range local {
 		if rAM, ok := remoteAM[lAM.FilePath]; !ok {

--- a/hosting/hosting.go
+++ b/hosting/hosting.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/10gen/stitch-cli/utils"
 )
@@ -45,7 +46,7 @@ func buildAssetMetadata(appID string, assetMetadata *[]AssetMetadata, rootDir st
 			if pathErr != nil {
 				return pathErr
 			}
-			assetPath := fmt.Sprintf("/%s", relPath)
+			assetPath := fmt.Sprintf("/%s", strings.ReplaceAll(relPath, "\\", "/"))
 
 			var desc *AssetDescription
 			if assetDescriptions != nil {
@@ -127,7 +128,8 @@ func MetadataFileToAssetDescriptions(path string) (map[string]AssetDescription, 
 
 	descM := make(map[string]AssetDescription, len(descs))
 	for _, desc := range descs {
-		descM[desc.FilePath] = desc
+		descFilePath := strings.ReplaceAll(desc.FilePath, "\\", "/")
+		descM[descFilePath] = desc
 	}
 
 	return descM, nil
@@ -181,7 +183,7 @@ func DiffAssetMetadata(local, remote []AssetMetadata, merge bool) *AssetMetadata
 	remoteAM := AssetsMetadata(remote).MapByPath()
 
 	// Ignore the root directory
-	delete(remoteAM, string(os.PathSeparator))
+	delete(remoteAM, "/")
 
 	for _, lAM := range local {
 		if rAM, ok := remoteAM[lAM.FilePath]; !ok {

--- a/hosting/hosting.go
+++ b/hosting/hosting.go
@@ -46,7 +46,7 @@ func buildAssetMetadata(appID string, assetMetadata *[]AssetMetadata, rootDir st
 			if pathErr != nil {
 				return pathErr
 			}
-			assetPath := fmt.Sprintf("/%s", strings.ReplaceAll(relPath, string(os.PathSeparator), "/"))
+			assetPath := fmt.Sprintf("/%s", ReplacePathSeparator(relPath))
 
 			var desc *AssetDescription
 			if assetDescriptions != nil {
@@ -128,7 +128,7 @@ func MetadataFileToAssetDescriptions(path string) (map[string]AssetDescription, 
 
 	descM := make(map[string]AssetDescription, len(descs))
 	for _, desc := range descs {
-		descFilePath := strings.ReplaceAll(desc.FilePath, string(os.PathSeparator), "/")
+		descFilePath := ReplacePathSeparator(desc.FilePath)
 		descM[descFilePath] = desc
 	}
 
@@ -235,4 +235,9 @@ func (amd *AssetMetadataDiffs) Diff() []string {
 	}
 
 	return diff
+}
+
+// ReplacePathSeparator returns path with os dependent path separators replaced by uniform '/'
+func ReplacePathSeparator(path string) string {
+	return strings.ReplaceAll(path, string(os.PathSeparator), "/")
 }

--- a/hosting/hosting.go
+++ b/hosting/hosting.go
@@ -46,7 +46,7 @@ func buildAssetMetadata(appID string, assetMetadata *[]AssetMetadata, rootDir st
 			if pathErr != nil {
 				return pathErr
 			}
-			assetPath := fmt.Sprintf("/%s", ReplacePathSeparator(relPath))
+			assetPath := fmt.Sprintf("/%s", replacePathSeparator(relPath))
 
 			var desc *AssetDescription
 			if assetDescriptions != nil {
@@ -128,7 +128,7 @@ func MetadataFileToAssetDescriptions(path string) (map[string]AssetDescription, 
 
 	descM := make(map[string]AssetDescription, len(descs))
 	for _, desc := range descs {
-		descFilePath := ReplacePathSeparator(desc.FilePath)
+		descFilePath := replacePathSeparator(desc.FilePath)
 		descM[descFilePath] = desc
 	}
 
@@ -238,6 +238,6 @@ func (amd *AssetMetadataDiffs) Diff() []string {
 }
 
 // ReplacePathSeparator returns path with os dependent path separators replaced by uniform '/'
-func ReplacePathSeparator(path string) string {
+func replacePathSeparator(path string) string {
 	return strings.ReplaceAll(path, string(os.PathSeparator), "/")
 }

--- a/hosting/models.go
+++ b/hosting/models.go
@@ -43,7 +43,6 @@ type AssetMetadata struct {
 
 // IsDir is true if the asset represents a directory
 func (amd *AssetMetadata) IsDir() bool {
-	// return strings.HasSuffix(amd.FilePath, "\\")
 	return strings.HasSuffix(amd.FilePath, string(os.PathSeparator))
 }
 

--- a/hosting/models.go
+++ b/hosting/models.go
@@ -2,6 +2,7 @@ package hosting
 
 import (
 	"encoding/json"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -42,7 +43,7 @@ type AssetMetadata struct {
 
 // IsDir is true if the asset represents a directory
 func (amd *AssetMetadata) IsDir() bool {
-	return strings.HasSuffix(amd.FilePath, "/")
+	return strings.HasSuffix(amd.FilePath, string(os.PathSeparator))
 }
 
 // NewAssetMetadata is a constructor for AssetMetadata

--- a/hosting/models.go
+++ b/hosting/models.go
@@ -43,6 +43,7 @@ type AssetMetadata struct {
 
 // IsDir is true if the asset represents a directory
 func (amd *AssetMetadata) IsDir() bool {
+	// return strings.HasSuffix(amd.FilePath, "\\")
 	return strings.HasSuffix(amd.FilePath, string(os.PathSeparator))
 }
 

--- a/hosting/models.go
+++ b/hosting/models.go
@@ -2,7 +2,6 @@ package hosting
 
 import (
 	"encoding/json"
-	"os"
 	"path"
 	"sort"
 	"strings"
@@ -43,7 +42,7 @@ type AssetMetadata struct {
 
 // IsDir is true if the asset represents a directory
 func (amd *AssetMetadata) IsDir() bool {
-	return strings.HasSuffix(amd.FilePath, string(os.PathSeparator))
+	return strings.HasSuffix(amd.FilePath, "/")
 }
 
 // NewAssetMetadata is a constructor for AssetMetadata


### PR DESCRIPTION
Fix issue that caused files imported via the cli on Windows to not maintain their file structure in the UI. See https://jira.mongodb.org/browse/HELP-11822. 

Fix: replace os.PathSeparator in file path to '/'. 