### PR TITLE
STITCH-4514: Temporarily remove replace-by-name from documented import strategy options

### DIFF
--- a/commands/import.go
+++ b/commands/import.go
@@ -107,11 +107,10 @@ OPTIONS:
   --project-id [string]
 	The Atlas Project ID.
 
-  --strategy [merge|replace|replace-by-name] (default: merge, recommended: replace-by-name)
+  --strategy [merge|replace]
 	How your app should be imported.
 	merge - import and overwrite existing entities while preserving those that exist on Stitch. Secrets missing will not be lost.
 	replace - like merge but does not preserve entities missing from the local directory's app configuration.
-	replace-by-name - like replace, but uses resource names instead of _id's for identity resolution
 
 
   --include-hosting

--- a/testdata/template_app_with_cluster/stitch.json
+++ b/testdata/template_app_with_cluster/stitch.json
@@ -6,5 +6,8 @@
       "enabled": false
     },
     "deployment_model": "GLOBAL",
+    "realm_config": {
+      "development_mode_enabled": false
+    },
     "security": {}
 }


### PR DESCRIPTION
* We reverted the server-side `replace-by-name` changes, so don't want to expose this yet